### PR TITLE
Fix path quotation

### DIFF
--- a/src/debug/executor/cppExecutor.ts
+++ b/src/debug/executor/cppExecutor.ts
@@ -257,7 +257,7 @@ using namespace std;
                     '-I',
                     thirdPartyPath,
                 ],
-                { windowsVerbatimArguments: false },
+                { shell: false },
             );
         } catch (e) {
             // vscode.window.showErrorMessage(e);

--- a/src/debug/executor/cppExecutor.ts
+++ b/src/debug/executor/cppExecutor.ts
@@ -243,9 +243,22 @@ using namespace std;
 
         try {
             const includePath: string = path.dirname(exePath);
-            await executeCommand('g++ -g', [
-                `${debugConfig.program} ${commonDestPath} ${jsonPath} -o ${exePath} -I ${includePath} -I ${thirdPartyPath}`,
-            ]);
+            await executeCommand(
+                'g++',
+                [
+                    '-g',
+                    debugConfig.program,
+                    commonDestPath,
+                    jsonPath,
+                    '-o',
+                    exePath,
+                    '-I',
+                    includePath,
+                    '-I',
+                    thirdPartyPath,
+                ],
+                { windowsVerbatimArguments: false },
+            );
         } catch (e) {
             // vscode.window.showErrorMessage(e);
             leetCodeChannel.show();


### PR DESCRIPTION
When spaces exist in any of these paths, like "C:\Program Files\VSCode\data\extensions", this command will fail because spaces are auto separated when execution. Just separating string args to array items is not enough. In windows, `windowsVerbatimArguments` will be auto set, hence spaces are still used as delimiters unless this option is specifically disabled.