### PR TITLE
Update entry.py

### DIFF
--- a/src/debug/entry/python3/entry.py
+++ b/src/debug/entry/python3/entry.py
@@ -265,9 +265,9 @@ def parseParameter(index, paramType, param):
     }
     switchfun = switch.get(paramType, 0)
 
-    if switchfun is 0:
+    if switchfun == 0:
         result = parseSpecialParameter(index, paramType, param)
-        if result is None:
+        if result == None:
             onParameterTypeError(paramType)
         return result
     else:


### PR DESCRIPTION
修改 is 为 == ，避免 python 3.8 环境中出现提示
SyntaxWarning: “is“ with a literal. Did you mean “==“?